### PR TITLE
Refactor table out to own component and make DataTable a variant

### DIFF
--- a/src/components/DataTable/DataTable.jsx
+++ b/src/components/DataTable/DataTable.jsx
@@ -1,0 +1,64 @@
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
+import { Table, TableHead, TableRow, TableBody, TableCell } from '../..';
+class DataTable extends Component {
+  static propTypes = {
+    className: PropTypes.string,
+    headers: PropTypes.arrayOf(
+      PropTypes.shape({
+        key: PropTypes.string,
+        label: PropTypes.string
+      })
+    ).isRequired,
+    rows: PropTypes.array.isRequired,
+    keyField: PropTypes.string.isRequired
+  };
+  static defaultProps = {
+    className: '',
+    headers: [],
+    rows: []
+  };
+
+  renderHeaders(headers) {
+    return headers.map(header => {
+      return (
+        <TableCell component="th" key={header.key}>
+          {header.label}
+        </TableCell>
+      );
+    });
+  }
+
+  renderRowColumns(headers, row, keyField) {
+    return headers.map(header => {
+      return (
+        <TableCell key={`${keyField}-${header.key}`}>
+          {row[header.key]}
+        </TableCell>
+      );
+    });
+  }
+  renderRows(headers, rows, keyField) {
+    return rows.map(row => {
+      return (
+        <TableRow key={row[keyField]}>
+          {this.renderRowColumns(headers, row, keyField)}
+        </TableRow>
+      );
+    });
+  }
+
+  render() {
+    const { headers, rows, keyField, ...rest } = this.props;
+    return (
+      <Table {...rest}>
+        <TableHead>
+          <TableRow>{this.renderHeaders(headers)}</TableRow>
+        </TableHead>
+        <TableBody>{this.renderRows(headers, rows, keyField)}</TableBody>
+      </Table>
+    );
+  }
+}
+
+export default DataTable;

--- a/src/components/DataTable/datatable.stories.js
+++ b/src/components/DataTable/datatable.stories.js
@@ -1,0 +1,18 @@
+import React from 'react';
+import { storiesOf } from '@storybook/react';
+import { DataTable } from '../../';
+
+let headers = [
+  { key: 'firstname', label: 'Firstname' },
+  { key: 'lastname', label: 'Lastname' },
+  { key: 'savings', label: 'Savings' }
+];
+let rows = [
+  { id: 1, firstname: 'Peter', lastname: 'Griffin', savings: '$100' },
+  { id: 2, firstname: 'Lois', lastname: 'Griffin', savings: '$150' },
+  { id: 3, firstname: 'Joe', lastname: 'Swanson', savings: '$300' },
+  { id: 4, firstname: 'Cleveland', lastname: 'Brown', savings: '$250' }
+];
+storiesOf('DataTable', module).add('Default', () => (
+  <DataTable headers={headers} rows={rows} keyField="id" />
+));

--- a/src/components/DataTable/index.js
+++ b/src/components/DataTable/index.js
@@ -1,0 +1,1 @@
+export { default as DataTable } from './DataTable.jsx';

--- a/src/components/Table/Table.jsx
+++ b/src/components/Table/Table.jsx
@@ -25,7 +25,13 @@ class Table extends Component {
   };
 
   renderTable() {
-    const { children, striped, condensed, caption, captionPosition } = this.props;
+    const {
+      children,
+      striped,
+      condensed,
+      caption,
+      captionPosition
+    } = this.props;
     return (
       <table
         className={cx(

--- a/src/components/Table/Table.jsx
+++ b/src/components/Table/Table.jsx
@@ -6,54 +6,46 @@ class Table extends Component {
   static propTypes = {
     className: PropTypes.string,
     responsive: PropTypes.bool,
-    headers: PropTypes.arrayOf(
-      PropTypes.shape({
-        key: PropTypes.string,
-        label: PropTypes.string
-      })
-    ).isRequired,
-    rows: PropTypes.array.isRequired,
-    keyField: PropTypes.string.isRequired
+    striped: PropTypes.bool,
+    condensed: PropTypes.bool,
+    children: PropTypes.oneOfType([
+      PropTypes.arrayOf(PropTypes.node),
+      PropTypes.node
+    ]).isRequired,
+    caption: PropTypes.string,
+    captionPosition: PropTypes.oneOf(['top', 'bottom'])
   };
   static defaultProps = {
     className: '',
     responsive: false,
-    headers: [],
-    rows: []
+    striped: false,
+    condensed: false,
+    caption: null,
+    captionPosition: 'top'
   };
 
-  renderHeaders() {
-    const { headers } = this.props;
-    return headers.map(header => {
-      return (
-        <th key={header.key} onClick={() => this.sortByColumn(header.key)}>
-          {header.label}
-        </th>
-      );
-    });
-  }
-
-  renderRowColumns(row) {
-    const { headers, keyField } = this.props;
-    return headers.map(header => {
-      return <td key={`${keyField}-${header.key}`}>{row[header.key]}</td>;
-    });
-  }
-  renderRows() {
-    const { rows, keyField } = this.props;
-    return rows.map(row => {
-      return <tr key={row[keyField]}>{this.renderRowColumns(row)}</tr>;
-    });
-  }
-
   renderTable() {
-    const { className } = this.props;
+    const { children, striped, condensed, caption, captionPosition } = this.props;
     return (
-      <table className={cx('dz-table', className)}>
-        <thead>
-          <tr>{this.renderHeaders()}</tr>
-        </thead>
-        <tbody>{this.renderRows()}</tbody>
+      <table
+        className={cx(
+          'dz-table',
+          { 'dz-table-striped': striped },
+          { 'dz-table-condensed': condensed }
+        )}
+      >
+        {caption !== null ? (
+          <caption
+            className={cx({
+              'dz-table-caption-bottom': captionPosition === 'bottom'
+            })}
+          >
+            {caption}
+          </caption>
+        ) : (
+          ''
+        )}
+        {children}
       </table>
     );
   }

--- a/src/components/Table/TableBody.jsx
+++ b/src/components/Table/TableBody.jsx
@@ -1,0 +1,19 @@
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
+
+class TableBody extends Component {
+  static propTypes = {
+    children: PropTypes.oneOfType([
+      PropTypes.arrayOf(PropTypes.node),
+      PropTypes.node
+    ]).isRequired
+  };
+  static defaultProps = {};
+
+  render() {
+    const { children, ...rest } = this.props;
+    return <tbody {...rest}>{children}</tbody>;
+  }
+}
+
+export default TableBody;

--- a/src/components/Table/TableCell.jsx
+++ b/src/components/Table/TableCell.jsx
@@ -1,0 +1,22 @@
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
+
+class TableCell extends Component {
+  static propTypes = {
+    children: PropTypes.oneOfType([
+      PropTypes.arrayOf(PropTypes.node),
+      PropTypes.node
+    ]).isRequired,
+    component: PropTypes.oneOf(['th', 'td'])
+  };
+  static defaultProps = {
+    component: 'td'
+  };
+
+  render() {
+    const { children, component: Component, ...rest } = this.props;
+    return <Component {...rest}>{children}</Component>;
+  }
+}
+
+export default TableCell;

--- a/src/components/Table/TableFoot.jsx
+++ b/src/components/Table/TableFoot.jsx
@@ -1,0 +1,19 @@
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
+
+class TableFoot extends Component {
+  static propTypes = {
+    children: PropTypes.oneOfType([
+      PropTypes.arrayOf(PropTypes.node),
+      PropTypes.node
+    ]).isRequired
+  };
+  static defaultProps = {};
+
+  render() {
+    const { children, ...rest } = this.props;
+    return <tfoot {...rest}>{children}</tfoot>;
+  }
+}
+
+export default TableFoot;

--- a/src/components/Table/TableHead.jsx
+++ b/src/components/Table/TableHead.jsx
@@ -1,0 +1,19 @@
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
+
+class TableHead extends Component {
+  static propTypes = {
+    children: PropTypes.oneOfType([
+      PropTypes.arrayOf(PropTypes.node),
+      PropTypes.node
+    ]).isRequired
+  };
+  static defaultProps = {};
+
+  render() {
+    const { children, ...rest } = this.props;
+    return <thead {...rest}>{children}</thead>;
+  }
+}
+
+export default TableHead;

--- a/src/components/Table/TableRow.jsx
+++ b/src/components/Table/TableRow.jsx
@@ -1,0 +1,19 @@
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
+
+class TableRow extends Component {
+  static propTypes = {
+    children: PropTypes.oneOfType([
+      PropTypes.arrayOf(PropTypes.node),
+      PropTypes.node
+    ]).isRequired
+  };
+  static defaultProps = {};
+
+  render() {
+    const { children, ...rest } = this.props;
+    return <tr {...rest}>{children}</tr>;
+  }
+}
+
+export default TableRow;

--- a/src/components/Table/index.js
+++ b/src/components/Table/index.js
@@ -1,1 +1,6 @@
 export { default as Table } from './Table.jsx';
+export { default as TableBody } from './TableBody.jsx';
+export { default as TableCell } from './TableCell.jsx';
+export { default as TableHead } from './TableHead.jsx';
+export { default as TableFoot } from './TableFoot.jsx';
+export { default as TableRow } from './TableRow.jsx';

--- a/src/components/Table/table.scss
+++ b/src/components/Table/table.scss
@@ -4,29 +4,51 @@
 .dz-table {
   width: 100%;
   margin-bottom: 1rem;
-  background-color: white;
+  background-color: $white;
   border-collapse: collapse;
   border-spacing: 0.125rem;
-  border-color: grey;
+  border-color: $borders;
   display: table;
 
+  .dz-table-caption-bottom {
+    caption-side: bottom;
+    margin-top: 5px;
+  }
+  caption {
+    margin-bottom: 5px;
+  }
   th,
   td {
     text-align: left;
     padding: 0.5rem;
   }
+
   thead {
     display: table-header-group;
     vertical-align: middle;
     border-color: inherit;
-
-    th {
+    th,
+    td {
       border-top: 0;
       border-bottom-width: 0.0625rem;
       padding-top: 0.5rem;
       padding-bottom: 0.5rem;
       vertical-align: bottom;
       border-bottom: 0.125rem solid $borders;
+    }
+  }
+  tfoot {
+    display: table-footer-group;
+    vertical-align: middle;
+    border-color: inherit;
+    th,
+    td {
+      border-bottom: 0;
+      border-top-width: 0.0625rem;
+      padding-top: 0.5rem;
+      padding-bottom: 0.5rem;
+      vertical-align: bottom;
+      border-top: 0.125rem solid $borders !important;
     }
   }
   tr {
@@ -61,9 +83,9 @@
   }
   &.dz-table-striped {
     tbody tr:nth-of-type(even) {
-      background-color: rgba(0, 0, 0, 0.02);
+      background-color: rgba($dark, 0.1);
       &:hover {
-        background-color: darken($color: $borders, $amount: 5%);
+        background-color: lighten($color: $dark, $amount: 50%);
       }
     }
   }
@@ -72,7 +94,8 @@
     td {
       padding: 0.25rem;
     }
-    thead {
+    thead,
+    tfoot {
       th {
         padding-top: 0.25rem;
         padding-bottom: 0.25rem;

--- a/src/components/Table/table.stories.js
+++ b/src/components/Table/table.stories.js
@@ -1,12 +1,13 @@
 import React from 'react';
 import { storiesOf } from '@storybook/react';
-import { Table } from '../../';
-
-let headers = [
-  { key: 'firstname', label: 'Firstname' },
-  { key: 'lastname', label: 'Lastname' },
-  { key: 'savings', label: 'Savings' }
-];
+import {
+  Table,
+  TableHead,
+  TableCell,
+  TableBody,
+  TableFoot,
+  TableRow
+} from '../../';
 
 let rows = [
   { id: 1, firstname: 'Peter', lastname: 'Griffin', savings: '$100' },
@@ -14,24 +15,121 @@ let rows = [
   { id: 3, firstname: 'Joe', lastname: 'Swanson', savings: '$300' },
   { id: 4, firstname: 'Cleveland', lastname: 'Brown', savings: '$250' }
 ];
+
 storiesOf('Table', module)
-  .add('Default', () => <Table headers={headers} rows={rows} keyField="id" />)
+  .add('Default', () => (
+    <Table>
+      <TableHead>
+        <TableRow>
+          <TableCell component="th">Firstname</TableCell>
+          <TableCell component="th">Lastname</TableCell>
+          <TableCell component="th">Savings</TableCell>
+        </TableRow>
+      </TableHead>
+      <TableBody>
+        {rows.map(item => {
+          return (
+            <TableRow key={item.id}>
+              <TableCell>{item.firstname}</TableCell>
+              <TableCell>{item.lastname}</TableCell>
+              <TableCell>{item.savings}</TableCell>
+            </TableRow>
+          );
+        })}
+      </TableBody>
+    </Table>
+  ))
   .add('Striped', () => (
-    <Table
-      headers={headers}
-      rows={rows}
-      keyField="id"
-      className="dz-table-striped"
-    />
+    <Table striped>
+      <TableHead>
+        <TableRow>
+          <TableCell component="th">Firstname</TableCell>
+          <TableCell component="th">Lastname</TableCell>
+          <TableCell component="th">Savings</TableCell>
+        </TableRow>
+      </TableHead>
+      <TableBody>
+        {rows.map(item => {
+          return (
+            <TableRow key={item.id}>
+              <TableCell>{item.firstname}</TableCell>
+              <TableCell>{item.lastname}</TableCell>
+              <TableCell>{item.savings}</TableCell>
+            </TableRow>
+          );
+        })}
+      </TableBody>
+    </Table>
   ))
   .add('Condensed', () => (
-    <Table
-      headers={headers}
-      rows={rows}
-      keyField="id"
-      className="dz-table-condensed"
-    />
+    <Table condensed>
+      <TableHead>
+        <TableRow>
+          <TableCell component="th">Firstname</TableCell>
+          <TableCell component="th">Lastname</TableCell>
+          <TableCell component="th">Savings</TableCell>
+        </TableRow>
+      </TableHead>
+      <TableBody>
+        {rows.map(item => {
+          return (
+            <TableRow key={item.id}>
+              <TableCell>{item.firstname}</TableCell>
+              <TableCell>{item.lastname}</TableCell>
+              <TableCell>{item.savings}</TableCell>
+            </TableRow>
+          );
+        })}
+      </TableBody>
+    </Table>
   ))
-  .add('Responsive', () => (
-    <Table responsive headers={headers} rows={rows} keyField="id" />
+  .add('With foot', () => (
+    <Table>
+      <TableHead>
+        <TableRow>
+          <TableCell component="th">Firstname</TableCell>
+          <TableCell component="th">Lastname</TableCell>
+          <TableCell component="th">Savings</TableCell>
+        </TableRow>
+      </TableHead>
+      <TableBody>
+        {rows.map(item => {
+          return (
+            <TableRow key={item.id}>
+              <TableCell>{item.firstname}</TableCell>
+              <TableCell>{item.lastname}</TableCell>
+              <TableCell>{item.savings}</TableCell>
+            </TableRow>
+          );
+        })}
+      </TableBody>
+      <TableFoot>
+        <TableRow>
+          <TableCell colspan="2">Sum</TableCell>
+          <TableCell>$800</TableCell>
+        </TableRow>
+      </TableFoot>
+    </Table>
+  ))
+  .add('With caption', () => (
+    <Table caption="Savings" captionPosition="bottom">
+      <TableHead>
+        <TableRow>
+          <TableCell component="th">Firstname</TableCell>
+          <TableCell component="th">Lastname</TableCell>
+          <TableCell component="th">Savings</TableCell>
+        </TableRow>
+      </TableHead>
+      <TableBody>
+        {rows.map(item => {
+          return (
+            <TableRow key={item.id}>
+              <TableCell>{item.firstname}</TableCell>
+              <TableCell>{item.lastname}</TableCell>
+              <TableCell>{item.savings}</TableCell>
+            </TableRow>
+          );
+        })}
+      </TableBody>
+    </Table>
   ));

--- a/src/index.js
+++ b/src/index.js
@@ -6,6 +6,7 @@ export * from './components/Button';
 export * from './components/Card';
 export * from './components/CheckBox';
 export * from './components/CheckBoxList';
+export * from './components/DataTable';
 export * from './components/Divider';
 export * from './components/Grid';
 export * from './components/IconSelect';


### PR DESCRIPTION
Making DataTable the primary table component was not the best way to go, and locked down the usage. These changes pulls the DataTable apart into the following components: 
- Table
- TableBody
- TableCell
- TableHead
- TableFoot
- TableRow

The original DataTable was re-created and uses these table components. 